### PR TITLE
Make jugglingdb-arango to work with new arango-client(arango) by modifying create() mathod for creating model objects(documents)

### DIFF
--- a/lib/arango.js
+++ b/lib/arango.js
@@ -61,7 +61,7 @@ Arango.prototype.fromDatabase = function(model, data) {
 };
 
 Arango.prototype.create = function (model, data, callback) {
-    this._client.document.create(true, model, data, function(err, res, hdr) {
+    this._client.document.create(model, data, {}, function(err, res, hdr) {
         if (callback) {
             callback(err, err ? null : res._id);
         }


### PR DESCRIPTION
Contains the fix for create() method of jugglingdb-arango based on new arango-client
